### PR TITLE
Modernize Python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,8 @@ src/test/histogram_test
 src/test/histogram_perf
 src/circllhist.ffi.h
 src/lua/ffi_libcircllhist.lua
+src/python/build
+src/python/circllhist/__pycache__
+src/python/circllhist.egg-info
 src/python/circllhist/ffi.py
+src/python/dist

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ src/test/histogram_perf
 src/circllhist.ffi.h
 src/lua/ffi_libcircllhist.lua
 src/python/build
+src/python/circllhist/*.pyc
 src/python/circllhist/__pycache__
 src/python/circllhist.egg-info
 src/python/circllhist/ffi.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os:
   - linux
 
+dist:
+  - focal
+
 compiler:
   - gcc
 
@@ -9,11 +12,11 @@ language:
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.8"
 
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install luajit -y
+  - sudo apt-get install luajit python3-cffi -y
 
 script:
   - buildtools/install-dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ python:
 
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install luajit python3-cffi -y
+  - sudo apt-get install luajit -y
+
+env:
+  - PATH: /home/travis/virtualenv/python2.7.18/bin:$PATH
 
 script:
   - buildtools/install-dependencies.sh

--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -1,31 +1,5 @@
 /*
  * Copyright (c) 2012-2018, Circonus, Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- *       copyright notice, this list of conditions and the following
- *       disclaimer in the documentation and/or other materials provided
- *       with the distribution.
- *     * Neither the name Circonus, Inc. nor the names of its contributors
- *       may be used to endorse or promote products derived from this
- *       software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/src/circllhist.h
+++ b/src/circllhist.h
@@ -1,32 +1,6 @@
 /** \file circllhist.h */
 /*
  * Copyright (c) 2016, Circonus, Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- *       copyright notice, this list of conditions and the following
- *       disclaimer in the documentation and/or other materials provided
- *       with the distribution.
- *     * Neither the name Circonus, Inc. nor the names of its contributors
- *       may be used to endorse or promote products derived from this
- *       software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*! \mainpage A C implementation of Circonus log-linear histograms

--- a/src/python/LICENSE
+++ b/src/python/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012-2021, Circonus, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name Circonus, Inc. nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -1,10 +1,11 @@
 # Python bindings for libcircllhist
 
-This package requires the libcircllhist C library to be installed on your system:
+This package requires the [OpenHistogram](https://openhistogram.io) C library,
+libcircllhist, to be installed on your system:
 
 https://github.com/openhistogram/libcircllhist/
 
-The bindings itself can be installed via pip:
+The bindings themselves can be installed via pip:
 
     pip install circllhist
 
@@ -22,6 +23,6 @@ import circllhist
 h = circllhist.Circllhist()
 h.insert(123,3)        # Insert value 123, three times
 h.insert_intscale(1,1) # Insert 1x10^1
-print(h.count())
-print(h.sum())
+print(h.count())       # Print the count of used bins
+print(h.sum())         # Print the sum of all values
 ```

--- a/src/python/RELEASE.md
+++ b/src/python/RELEASE.md
@@ -1,11 +1,8 @@
 # Release procedure
 
 * Edit setup.py and increase version number
-
-* Commit the change with a message:
-
-        Version bump to $version
-
-* Upload to pypi with:
-
-        ./setup.py sdist upload
+* Commit the change with a message: `Version bump to <version>`
+* Do a clean build of the C library to ensure the FFI wrapper is up to date
+* Upload to PyPI:
+  * To test: `twine upload --repository testpypi dist/*`
+  * For real: `twine upload dist/*`

--- a/src/python/RELEASE.md
+++ b/src/python/RELEASE.md
@@ -3,6 +3,7 @@
 * Edit setup.py and increase version number
 * Commit the change with a message: `Version bump to <version>`
 * Do a clean build of the C library to ensure the FFI wrapper is up to date
+* Perform the package build: `python -m build`
 * Upload to PyPI:
   * To test: `twine upload --repository testpypi dist/*`
   * For real: `twine upload dist/*`

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = [
+    "setuptools>=44"
+]

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -6,11 +6,19 @@ with open('README.md') as file:
 setup(
     name="circllhist",
     long_description=long_description,
-    version="0.3.0",
+    long_description_content_type='text/markdown',
+    version="0.3.1",
     description="OpenHistogram log-linear histogram library",
-    maintainer="Heinrich Hartmann",
-    maintainer_email="heinrich.hartmann@circonus.com",
+    maintainer="Circonus Packaging",
+    maintainer_email="packaging@circonus.com",
     url="https://github.com/openhistogram/libcircllhist",
     install_requires=['cffi'],
     packages=['circllhist'],
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: POSIX"
+    ],
+    python_requires=">=2.7",
 )

--- a/src/test/runTest.sh
+++ b/src/test/runTest.sh
@@ -64,11 +64,11 @@ pushd ../python
 if [ -z "$PYTHON_BIN" ]
 then
     set +e
-    PYTHON_BIN="$(command -v python3)"
+    PYTHON_BIN="$(command -v python)"
 
     if [ ! -x "$PYTHON_BIN" ]
     then
-        PYTHON_BIN="$(command -v python)"
+        PYTHON_BIN="$(command -v python3)"
     fi
     set -e
 fi


### PR DESCRIPTION
Update release process for current best practice.

Copy BSD license to ensure it is included in the package.